### PR TITLE
Fix when graphs re-render

### DIFF
--- a/packages/dashboard/src/components/AccountBreakdown.js
+++ b/packages/dashboard/src/components/AccountBreakdown.js
@@ -26,9 +26,14 @@ class AccountBreakdown extends React.Component {
     this.renderChart()
   }
 
-  componentDidUpdate(prevProps, props) {
-    // if selected account has changed re-render chart
-    this.renderChart()
+  componentDidUpdate(prevProps) {
+    // because we use 1d quotes to calculate portfolio value
+    // only re-render pie on deep unequality
+    if (
+      JSON.stringify(prevProps.historicQuotes['1d']) !==
+      JSON.stringify(this.props.historicQuotes['1d'])
+    )
+      this.renderChart()
   }
 
   renderChart = () => {

--- a/packages/dashboard/src/components/AccountOverview.js
+++ b/packages/dashboard/src/components/AccountOverview.js
@@ -34,12 +34,10 @@ class AccountOverview extends React.Component {
     this.renderChart()
   }
 
-  componentDidUpdate(prevProps, props) {
-    // if selected account hasnt changed, don't re-render chart
-    if (prevProps.selectedAccount?.value === props.selectedAccount?.value)
-      return
-
-    this.renderChart()
+  componentDidUpdate(prevProps, state) {
+    // if quotes have not changed, don't re-render chart
+    if (prevProps.historicQuotes !== this.props.historicQuotes)
+      this.renderChart()
   }
 
   selectRange = event => {
@@ -64,6 +62,8 @@ class AccountOverview extends React.Component {
     const currHistoricData =
       historicQuotes[selectedRange.toLowerCase()]?.results
 
+    const chartDefaultData = { ...chartData }
+
     // if the user selected a new range and we have data for it
     if (currHistoricData) {
       // get values
@@ -77,10 +77,10 @@ class AccountOverview extends React.Component {
       )
 
       // override default data
-      chartData.labels = labels
-      chartData.datasets = [
+      chartDefaultData.labels = labels
+      chartDefaultData.datasets = [
         {
-          ...chartData.datasets[0],
+          ...chartDefaultData.datasets[0],
           label: mainLabel,
           data: dataPoints,
         },
@@ -149,7 +149,7 @@ class AccountOverview extends React.Component {
 
     this.chartRef = new Chart(this.canvasRef.current, {
       type: 'LineWithLine',
-      data: chartData,
+      data: chartDefaultData,
       options: chartOptions,
     })
   }

--- a/packages/dashboard/src/components/AccountOverview.js
+++ b/packages/dashboard/src/components/AccountOverview.js
@@ -34,7 +34,7 @@ class AccountOverview extends React.Component {
     this.renderChart()
   }
 
-  componentDidUpdate(prevProps, state) {
+  componentDidUpdate(prevProps) {
     // if quotes have not changed, don't re-render chart
     if (prevProps.historicQuotes !== this.props.historicQuotes)
       this.renderChart()


### PR DESCRIPTION
- clear user state from main graph on logout
- only re-render main and pie graphs when we actually need to (ie appropriate data changes)
- main graph only re-renders on timeline change, pie graph never re-renders unless we happen to get new 1d quote data