### PR TITLE
Security lookup v1

### DIFF
--- a/packages/api/src/controllers/trade.ts
+++ b/packages/api/src/controllers/trade.ts
@@ -104,7 +104,7 @@ export async function getWatchlist(req, res, next) {
 export async function searchSecurity(req, res, next) {
   let securityQueryData = {}
   const tokens: Tokens = req.tokens
-  const query = req.params?.query
+  const query = req.query?.query
 
   if (!query) {
     return res

--- a/packages/dashboard/src/assets/styles.css
+++ b/packages/dashboard/src/assets/styles.css
@@ -6,3 +6,29 @@
 .securitySelected {
   background: #e1e5eb;
 }
+
+.searchIcon:hover {
+  color: #007bff;
+  cursor: pointer;
+}
+
+.securityDropDownContainer {
+  position: absolute;
+  margin-left: 25px;
+  max-height: 500px;
+  overflow-y: scroll;
+  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3);
+  border-radius: 0 0 0.625rem 0.625rem;
+}
+
+.securityDropDownItem {
+  font-weight: 500;
+  width: 400px;
+  background: #ffffff;
+  z-index: 100;
+  padding: 10px;
+}
+.securityDropDownItem:hover {
+  cursor: pointer;
+  background: #fbfbfb;
+}

--- a/packages/dashboard/src/components/layout/MainNavbar/MainNavbar.js
+++ b/packages/dashboard/src/components/layout/MainNavbar/MainNavbar.js
@@ -1,32 +1,132 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import { Container, Navbar } from 'shards-react'
+import { Container, Navbar, Row, Col } from 'shards-react'
+
+import { tradeActions } from '../../../redux/actions'
+import { searchSecurity } from '../../../utils/requests'
 
 import NavbarSearch from './NavbarSearch'
 import NavbarNav from './NavbarNav/NavbarNav'
 import NavbarToggle from './NavbarToggle'
 
-const MainNavbar = ({ layout, stickyTop }) => {
+const DropDownItem = ({
+  name,
+  symbol,
+  exchange,
+  id,
+  currency,
+  selectSecurity,
+}) => {
+  return (
+    <div
+      className="securityDropDownItem"
+      onClick={() => selectSecurity({ id, name, symbol, exchange, currency })}
+    >
+      <Row>
+        <Col className="col-9">{`${name} (${symbol})`}</Col>
+        <Col className="col-3">
+          <i>{exchange}</i>
+        </Col>
+      </Row>
+    </div>
+  )
+}
+
+const MainNavbar = ({ layout, stickyTop, history }) => {
   const classes = classNames(
     'main-navbar',
     'bg-white',
     stickyTop && 'sticky-top'
   )
 
+  const [searchSecurityError, setSearchSecurityError] = useState('')
+  const [securityResults, setSecurityResults] = useState([])
+  const [isSearchLoading, setIsSearchLoading] = useState(false)
+
+  const dispatch = useDispatch()
+
+  const tokens = useSelector(state => state.auth.user.tokens)
+
+  let searchTimer
+
+  const onSearch = e => {
+    clearTimeout(searchTimer)
+    setSearchSecurityError('')
+
+    const query = e.target.value
+    let queryResponse
+
+    // search after user has stopped typing query for 1s
+    searchTimer = setTimeout(async () => {
+      if (!query) {
+        setIsSearchLoading(false)
+        return setSecurityResults([])
+      }
+
+      setIsSearchLoading(true)
+
+      try {
+        queryResponse = (
+          await searchSecurity({
+            tokens: JSON.stringify(tokens),
+            query,
+          })
+        ).data.results
+      } catch (error) {
+        setSearchSecurityError(error.response?.data?.message)
+      }
+
+      setSecurityResults(queryResponse || [])
+      setIsSearchLoading(false)
+    }, 1000)
+  }
+
+  const onDropDownSecurityClick = security => {
+    setSecurityResults([])
+
+    dispatch(tradeActions.selectSecurity(security))
+
+    history.push('/trade')
+  }
+
+  const renderSecurityResults = () =>
+    securityResults.map(security => (
+      <DropDownItem
+        name={security.stock.name}
+        symbol={security.stock.symbol}
+        key={security.id}
+        exchange={security.stock.primary_exchange}
+        id={security.id}
+        currency={security.currency}
+        selectSecurity={onDropDownSecurityClick}
+      />
+    ))
+
   return (
-    <div className={classes}>
-      <Container className="p-0">
-        <Navbar
-          type="light"
-          className="align-items-stretch flex-md-nowrap p-0 justify-content-end"
-        >
-          <NavbarSearch />
-          <NavbarNav />
-          <NavbarToggle />
-        </Navbar>
-      </Container>
-    </div>
+    <>
+      <div className={classes}>
+        <Container className="p-0 m-0 mr-0" style={{ maxWidth: 1600 }}>
+          <Navbar
+            type="light"
+            className="align-items-stretch flex-md-nowrap p-0 justify-content-end"
+            style={{ borderBottom: '1px solid #ced4da' }}
+          >
+            <NavbarSearch onSearch={onSearch} loading={isSearchLoading} />
+            <NavbarNav />
+            <NavbarToggle />
+          </Navbar>
+        </Container>
+        <div className="securityDropDownContainer">
+          <div style={{ fontSize: 10, color: 'red' }}>
+            {searchSecurityError}
+          </div>
+          {renderSecurityResults()}
+        </div>
+      </div>
+    </>
   )
 }
 
@@ -45,4 +145,4 @@ MainNavbar.defaultProps = {
   stickyTop: true,
 }
 
-export default MainNavbar
+export default withRouter(MainNavbar)

--- a/packages/dashboard/src/components/layout/MainNavbar/MainNavbar.js
+++ b/packages/dashboard/src/components/layout/MainNavbar/MainNavbar.js
@@ -18,12 +18,14 @@ const DropDownItem = ({
   exchange,
   id,
   currency,
-  selectSecurity,
+  onDropDownSecurityClick,
 }) => {
   return (
     <div
       className="securityDropDownItem"
-      onClick={() => selectSecurity({ id, name, symbol, exchange, currency })}
+      onClick={() =>
+        onDropDownSecurityClick({ id, name, symbol, exchange, currency })
+      }
     >
       <Row>
         <Col className="col-9">{`${name} (${symbol})`}</Col>
@@ -101,7 +103,7 @@ const MainNavbar = ({ layout, stickyTop, history }) => {
         exchange={security.stock.primary_exchange}
         id={security.id}
         currency={security.currency}
-        selectSecurity={onDropDownSecurityClick}
+        onDropDownSecurityClick={onDropDownSecurityClick}
       />
     ))
 

--- a/packages/dashboard/src/components/layout/MainNavbar/NavbarSearch.js
+++ b/packages/dashboard/src/components/layout/MainNavbar/NavbarSearch.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { ClipLoader } from 'react-spinners'
 import {
   Form,
   InputGroup,
@@ -7,19 +8,22 @@ import {
   FormInput,
 } from 'shards-react'
 
-export default () => {
-  const [sarchValue, setSearchValue] = useState(null)
-
+export default ({ onSearch, loading = false }) => {
   return (
-    <Form className="main-navbar__search w-100 d-none d-md-flex d-lg-flex">
+    <Form
+      className="main-navbar__search w-100 d-none d-md-flex d-lg-flex"
+      onSubmit={e => e.preventDefalt()}
+    >
       <InputGroup seamless className="ml-3">
         <InputGroupAddon type="prepend">
           <InputGroupText>
-            <i className="material-icons">search</i>
+            <i className="material-icons searchIcon">search</i>
+            <ClipLoader size={15} color={'#007bff'} loading={loading} />
           </InputGroupText>
         </InputGroupAddon>
         <FormInput
-          onChange={e => setSearchValue(e.target.value)}
+          style={{ paddingLeft: 40 }}
+          onChange={onSearch}
           className="navbar-search"
           placeholder="Search for an option..."
         />

--- a/packages/dashboard/src/components/layout/MainSidebar/SidebarSearch.js
+++ b/packages/dashboard/src/components/layout/MainSidebar/SidebarSearch.js
@@ -15,11 +15,11 @@ export default () => (
     <InputGroup seamless className="ml-3">
       <InputGroupAddon type="prepend">
         <InputGroupText>
-          <i className="material-icons">search</i>
+          <i className="material-icons searchIcon">search</i>
         </InputGroupText>
         <FormInput
           className="navbar-search"
-          placeholder="Search for something..."
+          placeholder="Search for an option..."
           aria-label="Search"
         />
       </InputGroupAddon>

--- a/packages/dashboard/src/views/Trade.js
+++ b/packages/dashboard/src/views/Trade.js
@@ -24,7 +24,6 @@ const Trade = ({ chartData }) => {
 
   // select security from portfolio
   const selectSecurity = security => {
-    setSelectedRange('1d')
     dispatch(tradeActions.selectSecurity(security))
   }
 
@@ -33,6 +32,10 @@ const Trade = ({ chartData }) => {
   const [currentChartData, setCurrentChartData] = useState(chartData)
 
   // useEffects
+
+  // reset selected range when security changes
+  useEffect(() => setSelectedRange('1d'), [selectedSecurity?.id])
+
   useEffect(() => {
     // if we have data for a selected range, generate new chart data
     if (!!selectedSecurity?.historicQuotes?.[selectedRange]) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29992628/79028364-b5c54200-7b5d-11ea-9e53-30042f2d3913.png)
![image](https://user-images.githubusercontent.com/29992628/79028393-d392a700-7b5d-11ea-8fe7-6bceeb64e585.png)

- Add the ability to search for securities in the global header
- Pretty rough right now, but it populates our selectedSecurity and will allow the user to interact with the graph

Features:
- Auto fetch on user input
- Redirects to Trade page
- Simplifies security selection logic

TODO:
- add to mobile view
- add view when an account is not selected (preview stock like in portfolio sidebar) and if account is selected, add logic to add the preview IF it is not already in portfolio.
- Add the other stats / info below the graph where you can add to watchlist, and buy/sell
