### PR TITLE
Small fixes!

### DIFF
--- a/packages/dashboard/src/components/MainChart.js
+++ b/packages/dashboard/src/components/MainChart.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import _ from 'lodash'
 import PropTypes from 'prop-types'
 import {
   Card,
@@ -10,6 +11,7 @@ import {
   Col,
 } from 'shards-react'
 import { ClipLoader } from 'react-spinners'
+import { usePrevious } from '../utils/hooks'
 
 const MainChart = ({
   overrideRanges,
@@ -30,11 +32,14 @@ const MainChart = ({
     setselectedRange('1d')
   }, [chartTitle])
 
+  const currChartData = chartData?.data?.datasets?.[0]?.data
+  const prevChartData = usePrevious(currChartData)
+
   useEffect(() => {
     if (chartData?.data) {
       renderChart()
     }
-  }, [chartData?.data?.datasets?.[0]?.data])
+  }, [!_.isEqual(currChartData, prevChartData)])
 
   const onRangeClick = e => {
     // update internal selected state

--- a/packages/dashboard/src/components/layout/MainNavbar/MainNavbar.js
+++ b/packages/dashboard/src/components/layout/MainNavbar/MainNavbar.js
@@ -50,7 +50,7 @@ const MainNavbar = ({ layout, stickyTop, history }) => {
 
   const dispatch = useDispatch()
 
-  const tokens = useSelector(state => state.auth.user.tokens)
+  const tokens = useSelector(state => state.auth?.user?.tokens)
 
   let searchTimer
 

--- a/packages/dashboard/src/components/layout/MainNavbar/NavbarNav/NavbarNav.js
+++ b/packages/dashboard/src/components/layout/MainNavbar/NavbarNav/NavbarNav.js
@@ -1,16 +1,19 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { Nav } from 'shards-react'
+import { ClipLoader } from 'react-spinners'
 
-import Notifications from './Notifications'
 import UserActions from './UserActions'
 
 const NavBar = props => {
-  const { user, isLoggedIn } = props
+  const { user, isLoggedIn, isStatusLoading } = props
 
   return (
     <Nav navbar className="border-left flex-row">
       {/* <Notifications /> */}
+      {isStatusLoading && (
+        <ClipLoader loading={isStatusLoading} size={50} color="#007bff" />
+      )}
       {isLoggedIn && <UserActions user={user} isLoggedIn={isLoggedIn} />}
     </Nav>
   )
@@ -19,6 +22,7 @@ const NavBar = props => {
 const mapStateToProps = state => ({
   user: state.auth.user,
   isLoggedIn: state.auth.isLoggedIn,
+  isStatusLoading: state.auth.isStatusLoading,
 })
 
 export default connect(mapStateToProps)(NavBar)

--- a/packages/dashboard/src/utils/hooks.js
+++ b/packages/dashboard/src/utils/hooks.js
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react'
+
+export const usePrevious = value => {
+  const ref = useRef()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}

--- a/packages/dashboard/src/views/Trade.js
+++ b/packages/dashboard/src/views/Trade.js
@@ -58,12 +58,14 @@ const Trade = ({ chartData }) => {
 
     setSelectedRange(selectedRange)
 
-    dispatch(
-      tradeActions.getSecurityHistory({
-        securityId: selectedSecurity.id,
-        time: selectedRange,
-      })
-    )
+    if (!selectedSecurity?.historicQuotes?.[selectedRange]) {
+      dispatch(
+        tradeActions.getSecurityHistory({
+          securityId: selectedSecurity.id,
+          time: selectedRange,
+        })
+      )
+    }
   }
 
   const getChartData = () => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29992628/79167598-cec83000-7db5-11ea-9aa8-fb5d9f56502c.png)

- Add a spinner for checking the profile status in the top right

- Cache the security historical info. Realistically you won't need to fetch new data on every click. We still fetch historical profile data on every click

- Fix the chart re-render by debouncing chart data with new usePrevious hook - https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state. This will now only render the chart if the array data changes, which is what I thought it was doing beforehand. What I was doing beforehand was fine, but we were mutating the array, so useEffect thought it was different. This will now explicitly check the data values with a lodash deep equality check. Also started the hooks file for custom hooks.