### PR TITLE
Auto select account

### DIFF
--- a/packages/dashboard/src/components/SecurityList.js
+++ b/packages/dashboard/src/components/SecurityList.js
@@ -59,7 +59,7 @@ const Security = ({
                 style={{
                   color: gain.value < 0 ? gainStyles.red : gainStyles.green,
                 }}
-              >{`${Math.round(gain.value * 100) / 100} (${Math.round(
+              >{`$${Math.round(gain.value * 100) / 100} (${Math.round(
                 gain.percent * 100
               ) / 100}%)`}</span>{' '}
               {currency}

--- a/packages/dashboard/src/redux/sagas/auth.js
+++ b/packages/dashboard/src/redux/sagas/auth.js
@@ -28,7 +28,7 @@ function* getUserStatus({ payload }) {
 
   // default to the first account as our selected account if we have accounts
   const accounts = statusResponse?.data?.portfolioData
-  if (accounts && Object.keys(accounts)) {
+  if (accounts && Object.keys(accounts).length) {
     const firstAccountId = Object.keys(accounts)[0]
     yield put(tradeActions.selectAccount(getFormattedAccount(firstAccountId)))
   }
@@ -59,7 +59,7 @@ function* attemptLoginUser({ payload }) {
 
   // default to the first account as our selected account if we have accounts
   const accounts = loginResponse?.data?.portfolioData
-  if (accounts && Object.keys(accounts)) {
+  if (accounts && Object.keys(accounts).length) {
     const firstAccountId = Object.keys(accounts)[0]
     yield put(tradeActions.selectAccount(getFormattedAccount(firstAccountId)))
   }

--- a/packages/dashboard/src/redux/sagas/auth.js
+++ b/packages/dashboard/src/redux/sagas/auth.js
@@ -1,8 +1,8 @@
 import { put, takeLatest } from 'redux-saga/effects'
 import { LOGIN_USER, LOGOUT_USER, GET_STATUS } from '../constants'
-import { authActions } from '../actions'
+import { authActions, tradeActions } from '../actions'
 import { loginUser, getStatus } from '../../utils/requests'
-import { createResponse } from '../../utils/helpers'
+import { createResponse, getFormattedAccount } from '../../utils/helpers'
 
 // STATUS
 function* getUserStatus({ payload }) {
@@ -21,6 +21,14 @@ function* getUserStatus({ payload }) {
       {},
       true
     )
+  }
+
+  const accounts = statusResponse?.data?.portfolioData
+
+  // if we have accounts, default to the first one as our selected account
+  if (accounts && Object.keys(accounts)) {
+    const firstAccountId = Object.keys(accounts)[0]
+    yield put(tradeActions.selectAccount(getFormattedAccount(firstAccountId)))
   }
 
   return yield put(authActions.statusResponse(statusResponse))

--- a/packages/dashboard/src/redux/sagas/auth.js
+++ b/packages/dashboard/src/redux/sagas/auth.js
@@ -23,15 +23,15 @@ function* getUserStatus({ payload }) {
     )
   }
 
-  const accounts = statusResponse?.data?.portfolioData
+  // dispatch auth response
+  yield put(authActions.statusResponse(statusResponse))
 
-  // if we have accounts, default to the first one as our selected account
+  // default to the first account as our selected account if we have accounts
+  const accounts = statusResponse?.data?.portfolioData
   if (accounts && Object.keys(accounts)) {
     const firstAccountId = Object.keys(accounts)[0]
     yield put(tradeActions.selectAccount(getFormattedAccount(firstAccountId)))
   }
-
-  return yield put(authActions.statusResponse(statusResponse))
 }
 
 // LOGIN
@@ -56,6 +56,13 @@ function* attemptLoginUser({ payload }) {
   // if login is successful, update tokens and dispatch success
   window.localStorage.tokens = JSON.stringify(loginResponse.data.tokens)
   yield put(authActions.loginSuccess(loginResponse))
+
+  // default to the first account as our selected account if we have accounts
+  const accounts = loginResponse?.data?.portfolioData
+  if (accounts && Object.keys(accounts)) {
+    const firstAccountId = Object.keys(accounts)[0]
+    yield put(tradeActions.selectAccount(getFormattedAccount(firstAccountId)))
+  }
 }
 
 // LOGOUT

--- a/packages/dashboard/src/views/Holdings.js
+++ b/packages/dashboard/src/views/Holdings.js
@@ -47,21 +47,19 @@ const Holdings = ({
     message: '',
   })
 
+  // update UI and internal state to use defaulted selected account
   useEffect(() => {
-    // on load set dropdown and current account state from redux
     if (globalSelectedAccount) {
+      // set account dropdown
       setDropdownState({
         isOpen: false,
         selected: globalSelectedAccount,
       })
-      setSelectedAccount({
-        ...accounts[globalSelectedAccount.value],
-        value: globalSelectedAccount.value,
-      })
-    }
 
-    return () => {}
-  }, [])
+      // set the selected account state locally
+      setSelectedAccount(accounts[globalSelectedAccount.value])
+    }
+  }, [accounts])
 
   useEffect(() => {
     // fetch 1d stats for account overview on account switch
@@ -72,8 +70,6 @@ const Holdings = ({
         tokens: JSON.stringify(user.tokens),
       })
     }
-
-    return () => null
   }, [selectedAccount])
 
   useEffect(() => {
@@ -122,10 +118,8 @@ const Holdings = ({
     })
 
     // set the selected account locally
-    setSelectedAccount({
-      ...accounts[currentAccount.value],
-      value: currentAccount.value,
-    })
+    // TODO GET RID OF INTERNAL STATE< DISPATCH ACTION HERE
+    setSelectedAccount(accounts[currentAccount.value])
 
     // dispatch selected account to redux
     selectAccount(currentAccount)

--- a/packages/dashboard/src/views/Holdings.js
+++ b/packages/dashboard/src/views/Holdings.js
@@ -34,39 +34,34 @@ const Holdings = ({
   getHistory,
   user,
   historicQuotes,
-  globalSelectedAccount,
+  selectedAccountInfo,
   isHistoryLoading,
 }) => {
   const [dropdownState, setDropdownState] = useState({
     isOpen: false,
     selected: null,
   })
-  const [selectedAccount, setSelectedAccount] = useState(null)
   const [alertData, setAlertData] = useState({
     isShowing: false,
     message: '',
   })
 
-  // update UI and internal state to use defaulted selected account
+  // selected account contains the account ID and display only, not account data
+  const selectedAccount = accounts[selectedAccountInfo?.value]
+
+  // set selected account information and fetch data on load or account change
   useEffect(() => {
-    if (globalSelectedAccount) {
-      // set account dropdown
+    if (selectedAccount) {
+      // set account dropdown to correct account
       setDropdownState({
         isOpen: false,
-        selected: globalSelectedAccount,
+        selected: selectedAccountInfo,
       })
 
-      // set the selected account state locally
-      setSelectedAccount(accounts[globalSelectedAccount.value])
-    }
-  }, [accounts])
-
-  useEffect(() => {
-    // fetch 1d stats for account overview on account switch
-    if (!!selectedAccount) {
+      // fetch initial data used for account overview
       getHistory({
         times: ['1d', 'all'],
-        account: dropdownState.selected.value,
+        account: selectedAccountInfo.value,
         tokens: JSON.stringify(user.tokens),
       })
     }
@@ -76,6 +71,7 @@ const Holdings = ({
     if (!isHistoryLoading) {
       // if markets just opened and we don't have data yet
       if (
+        Object.keys(historicQuotes).length &&
         !isHistoryDataValid(['1d', 'all'], historicQuotes) &&
         selectedAccount &&
         !alertData.isShowing
@@ -96,7 +92,6 @@ const Holdings = ({
         })
       }
     }
-    return () => {}
   }, [historicQuotes])
 
   // TODO shards dropdowns are jank... figure out a better way to do this
@@ -116,10 +111,6 @@ const Holdings = ({
       isOpen: false,
       selected: currentAccount,
     })
-
-    // set the selected account locally
-    // TODO GET RID OF INTERNAL STATE< DISPATCH ACTION HERE
-    setSelectedAccount(accounts[currentAccount.value])
 
     // dispatch selected account to redux
     selectAccount(currentAccount)
@@ -537,7 +528,7 @@ const mapStateToProps = state => ({
   user: state.auth.user,
   historicQuotes: state.trade.historicQuotes,
   isHistoryLoading: state.trade.isHistoryLoading,
-  globalSelectedAccount: state.trade.selectedAccount,
+  selectedAccountInfo: state.trade.selectedAccount,
 })
 
 const mapDispatchToProps = {


### PR DESCRIPTION
- auto select an account on login and getStatus so the user does not have to manually select one initially
- simplify and clean up some internal account state in `Holdings.js`
- add check on if we have historic quotes before showing the markets delayed banner
- add a $ to an increase